### PR TITLE
Fix #7: harden reverse-proxy base-path handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project should be documented in this file.
+
+## v1.2.3 — Reverse-proxy path fix
+
+- Fixed frontend base-path handling for reverse-proxy / subpath deployments.
+- BrowserRouter now respects the deployed Vite base path instead of assuming `/`.
+- Login redirect on 401 now resolves through the frontend base path.
+- Logo asset paths and RDP download URLs now work correctly behind proxied subpaths.
+- Added `frontend/src/vite-env.d.ts` so `import.meta.env.BASE_URL` builds cleanly in TypeScript.
+
+## v1.2.2 — Bug fix: TopBar new-device counter
+
+- Fixed the TopBar new-device counter to stay consistent with the Dashboard logic.
+
+## v1.2.1 — Bug fixes & segment enhancements
+
+- Fixed unregistered counter behavior for viewed devices.
+- Improved segment filtering and IP usage display.
+
+## v1.2.0 — Server URL, Telegram update notifications, sortable table & more device classes
+
+- Added server URL setting for reverse-proxy deployments.
+- Added Telegram update notifications.
+- Added sortable device table and more device classes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.12-slim
 
 LABEL org.opencontainers.image.title="LanLens" \
       org.opencontainers.image.description="Self-hosted network monitoring dashboard" \
-      org.opencontainers.image.version="1.2.2" \
+      org.opencontainers.image.version="1.2.3" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source="https://github.com/AlexRosbach/LanLens"
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Self-hosted network monitoring & documentation dashboard**
 
-[![Version](https://img.shields.io/badge/version-1.2.2-6366f1)](https://github.com/AlexRosbach/LanLens/releases/latest)
+[![Version](https://img.shields.io/badge/version-1.2.3-6366f1)](https://github.com/AlexRosbach/LanLens/releases/latest)
 [![License: MIT](https://img.shields.io/badge/license-MIT-22c55e)](LICENSE)
 [![Docker Hub](https://img.shields.io/docker/pulls/alexrosbach/lanlens?color=0ea5e9)](https://hub.docker.com/r/alexrosbach/lanlens)
 
@@ -339,6 +339,13 @@ Your data volume (`lanlens_data`) is preserved across upgrades.
 ---
 
 ## Changelog
+
+### v1.2.3 — Reverse-proxy path fix
+
+- **Frontend base-path handling hardened** — BrowserRouter now respects the deployed Vite base path instead of assuming LanLens always runs at `/`
+- **Login redirect fixed for subpath deployments** — 401 handling now redirects to the correct proxied login URL instead of forcing `/login` at the domain root
+- **Asset URLs fixed for proxied installs** — logo and direct RDP download URLs now use the configured frontend base path so reverse-proxy/subpath setups keep working consistently
+- **Build typing fix** — added `vite-env.d.ts` so `import.meta.env.BASE_URL` builds cleanly in TypeScript
 
 ### v1.2.2 — Bug fix: TopBar new-device counter
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -78,7 +78,7 @@ async def lifespan(app: FastAPI):
     logger.info("LanLens stopped")
 
 
-APP_VERSION = "1.2.2"
+APP_VERSION = "1.2.3"
 
 app = FastAPI(
     title="LanLens",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "lanlens",
   "private": true,
-  "version": "1.2.2",
+  "version": "1.2.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
+import { getBasePath } from './utils/basePath'
 import Layout from './components/layout/Layout'
 import Dashboard from './pages/Dashboard'
 import DeviceDetail from './pages/DeviceDetail'
@@ -56,7 +57,7 @@ export default function App() {
 
   return (
     <I18nProvider>
-      <BrowserRouter>
+      <BrowserRouter basename={getBasePath() || undefined}>
         <Routes>
           <Route
             path="/login"

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
 import axios from 'axios'
+import { withBasePath } from '../utils/basePath'
 
 const apiClient = axios.create({
   baseURL: '/api',
@@ -21,7 +22,7 @@ apiClient.interceptors.response.use(
     if (error.response?.status === 401) {
       localStorage.removeItem('lanlens_token')
       localStorage.removeItem('lanlens_user')
-      window.location.href = '/login'
+      window.location.href = withBasePath('/login')
     }
     return Promise.reject(error)
   },

--- a/frontend/src/api/devices.ts
+++ b/frontend/src/api/devices.ts
@@ -1,5 +1,6 @@
 import apiClient from './client'
 import type { Service } from './services'
+import { withBasePath } from '../utils/basePath'
 
 export interface PortInfo { port: number; protocol: string; service: string; state: string }
 export interface PortScanResult {
@@ -89,5 +90,5 @@ export const devicesApi = {
   getPorts: (id: number) =>
     apiClient.get<PortScanResult[]>(`/devices/${id}/ports`).then((r) => r.data),
 
-  getRdpUrl: (id: number) => `/api/connect/${id}/rdp`,
+  getRdpUrl: (id: number) => withBasePath(`/api/connect/${id}/rdp`),
 }

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { NavLink, useNavigate } from 'react-router-dom'
+import { withBasePath } from '../../utils/basePath'
 import { useDeviceStore } from '../../store/deviceStore'
 import { useNotificationStore } from '../../store/notificationStore'
 import { useI18n } from '../../i18n'
@@ -73,7 +74,7 @@ export default function Sidebar({ onClose }: Props) {
           onClick={() => { navigate('/'); handleNavClick() }}
           className="flex items-center gap-3 hover:opacity-80 transition-opacity"
         >
-          <img src="/logo.svg" alt="LanLens" className="w-8 h-8" />
+          <img src={withBasePath('/logo.svg')} alt="LanLens" className="w-8 h-8" />
           <span className="text-lg font-bold text-text-base tracking-tight">LanLens</span>
         </button>
         {/* Close button on mobile */}

--- a/frontend/src/pages/ForcePasswordChange.tsx
+++ b/frontend/src/pages/ForcePasswordChange.tsx
@@ -5,6 +5,7 @@ import { authApi } from '../api/auth'
 import { useAuthStore } from '../store/authStore'
 import Button from '../components/ui/Button'
 import Input from '../components/ui/Input'
+import { withBasePath } from '../utils/basePath'
 
 export default function ForcePasswordChange() {
   const [current, setCurrent] = useState('')
@@ -45,7 +46,7 @@ export default function ForcePasswordChange() {
     <div className="min-h-screen bg-background flex items-center justify-center p-4">
       <div className="w-full max-w-sm">
         <div className="flex flex-col items-center mb-6">
-          <img src="/logo.svg" alt="LanLens" className="w-12 h-12 mb-3" />
+          <img src={withBasePath('/logo.svg')} alt="LanLens" className="w-12 h-12 mb-3" />
           <h1 className="text-xl font-bold text-text-base">Set Your Password</h1>
           <p className="text-sm text-text-muted mt-1 text-center">
             For security, please change the default password before continuing.

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast'
 import { useAuthStore } from '../store/authStore'
 import Button from '../components/ui/Button'
 import Input from '../components/ui/Input'
+import { withBasePath } from '../utils/basePath'
 
 export default function Login() {
   const [username, setUsername] = useState('')
@@ -46,7 +47,7 @@ export default function Login() {
       <div className="w-full max-w-sm relative">
         {/* Logo + title */}
         <div className="flex flex-col items-center mb-8">
-          <img src="/logo.svg" alt="LanLens" className="w-16 h-16 mb-4" />
+          <img src={withBasePath('/logo.svg')} alt="LanLens" className="w-16 h-16 mb-4" />
           <h1 className="text-2xl font-bold text-text-base tracking-tight">LanLens</h1>
           <p className="text-sm text-text-muted mt-1">Network Monitoring Dashboard</p>
         </div>

--- a/frontend/src/utils/basePath.ts
+++ b/frontend/src/utils/basePath.ts
@@ -1,0 +1,11 @@
+export function getBasePath(): string {
+  const base = import.meta.env.BASE_URL || '/'
+  if (!base || base === '/') return ''
+  return base.endsWith('/') ? base.slice(0, -1) : base
+}
+
+export function withBasePath(path: string): string {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  const base = getBasePath()
+  return base ? `${base}${normalizedPath}` : normalizedPath
+}

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = '1.2.2'
+export const APP_VERSION = '1.2.3'
 export const GITHUB_REPO = 'AlexRosbach/LanLens'

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- fix frontend base-path handling for reverse-proxy / subpath deployments
- stop forcing root-relative login redirects and asset URLs
- make BrowserRouter respect the deployed Vite base path
- add root CHANGELOG.md and bump version to v1.2.3

## Why
Issue #7 reports missing data when LanLens is served behind another NGINX reverse proxy. The backend routes look consistent, but the frontend assumed root deployment (`/`) in several places, which is brittle behind proxied subpaths.

## Changes
- add `frontend/src/utils/basePath.ts`
- use Vite base path in BrowserRouter
- fix 401 redirect to login via base path
- fix logo asset paths on auth/sidebar screens
- fix RDP download URL generation behind subpaths
- add `frontend/src/vite-env.d.ts` for `import.meta.env.BASE_URL`
- document the change in `README.md` and new root `CHANGELOG.md`
- bump version to `1.2.3`

## Validation
- `npm run build` ✅

Closes #7
