### PR TITLE
fix(devices): allow deleting devices with relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project should be documented in this file.
 
+## v1.4.2 — Device delete fix and stability improvements
+
+### Bug Fixes
+- Fixed device deletion from Device Detail. Devices with related VM host/guest relationships can now be removed cleanly together with their dependent records instead of failing during delete.
+
 ## v1.4.1 — Deep Scan improvements, OS-specific device classes, VM-host linking, CMDB, MariaDB & more
 
 ### Bug Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM python:3.12-slim
 
 LABEL org.opencontainers.image.title="LanLens" \
       org.opencontainers.image.description="Self-hosted network monitoring dashboard" \
-      org.opencontainers.image.version="1.4.1" \
+      org.opencontainers.image.version="1.4.2" \
       org.opencontainers.image.licenses="MIT" \
       org.opencontainers.image.source="https://github.com/AlexRosbach/LanLens"
 

--- a/backend/models.py
+++ b/backend/models.py
@@ -69,6 +69,16 @@ class Device(Base):
     deep_scan_runs = relationship("DeepScanRun", back_populates="device", cascade="all, delete-orphan")
     deep_scan_findings = relationship("DeepScanFinding", back_populates="device",
                                       cascade="all, delete-orphan")
+    host_relationships = relationship(
+        "DeviceHostRelationship",
+        foreign_keys="DeviceHostRelationship.host_device_id",
+        cascade="all, delete-orphan",
+    )
+    child_relationships = relationship(
+        "DeviceHostRelationship",
+        foreign_keys="DeviceHostRelationship.child_device_id",
+        cascade="all, delete-orphan",
+    )
 
 
 class Service(Base):

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,2 +1,2 @@
-export const APP_VERSION = '1.4.1'
+export const APP_VERSION = '1.4.2'
 export const GITHUB_REPO = 'AlexRosbach/LanLens'


### PR DESCRIPTION
## Summary
- fix Device Detail delete for devices with host or guest relationships
- bump release version to 1.4.2
- update changelog and image metadata

Closes #33

## Why
Deleting a device could fail when related VM host or guest relationships still existed. The backend model did not cascade those relationship rows from the device side.

## Validation
- docker build completed successfully for tags 1.4.2 and test
