### PR TITLE
docs(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Report a reproducible problem or regression in LanLens.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug. Please fill in the details below so the issue can be reproduced and fixed faster.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: Describe the problem and the actual behavior.
+      placeholder: Devices are shown as offline even though they are reachable.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+      placeholder: Devices should remain online unless they have really disappeared from the network.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Provide exact steps if possible.
+      placeholder: |
+        1. Open Devices
+        2. Wait for a scheduled scan
+        3. Observe that several active devices flip to offline
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Share the most relevant environment details.
+      placeholder: |
+        - LanLens version: 1.4.3
+        - Deployment: Docker / Docker Compose
+        - Host OS: Debian 13
+        - Browser: Firefox 145
+        - Network size: around 100 devices
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs, screenshots, or additional context
+      description: Paste logs or add screenshots if they help.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checks
+      options:
+        - label: I am using a current LanLens version or I have verified the problem still exists on a recent test build.
+          required: false
+        - label: I searched existing issues and did not find an identical report.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security issue
+    url: https://github.com/AlexRosbach/LanLens/security/advisories/new
+    about: Please report sensitive security vulnerabilities privately.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Security issue
     url: https://github.com/AlexRosbach/LanLens/security/advisories/new

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature request
+description: Suggest an improvement or a new capability for LanLens.
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. Clear feature requests help a lot when prioritizing and implementing improvements.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      placeholder: Managing device segments manually is confusing and error-prone.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What would you like to happen?
+      placeholder: Segment assignment should be calculated automatically from IP ranges.
+    validations:
+      required: true
+
+  - type: textarea
+    id: benefit
+    attributes:
+      label: Why would this help?
+      placeholder: It would remove duplicate maintenance and make the UI easier to understand.
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives or workarounds you considered
+      placeholder: A manual override would also work, but automatic calculation would be cleaner.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context, mockups, or screenshots

--- a/.github/ISSUE_TEMPLATE/question_or_support.yml
+++ b/.github/ISSUE_TEMPLATE/question_or_support.yml
@@ -1,0 +1,33 @@
+name: Question / support
+description: Ask a usage question or get help with setup, configuration, or expected behavior.
+title: "[Question]: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for setup questions, expected behavior, or general support topics.
+
+  - type: textarea
+    id: question
+    attributes:
+      label: What do you need help with?
+      placeholder: How should scan ranges be configured when LanLens runs in Docker on a different subnet?
+    validations:
+      required: true
+
+  - type: textarea
+    id: details
+    attributes:
+      label: Relevant details
+      placeholder: |
+        - LanLens version:
+        - Deployment method:
+        - Network setup:
+        - What you already tried:
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Logs, screenshots, or extra context

--- a/.github/ISSUE_TEMPLATE/translation_issue.yml
+++ b/.github/ISSUE_TEMPLATE/translation_issue.yml
@@ -1,0 +1,46 @@
+name: Translation issue
+description: Report missing, incorrect, or inconsistent translations in the UI.
+title: "[Translation]: "
+labels:
+  - i18n
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for missing translations, mixed-language UI, or wording issues.
+
+  - type: input
+    id: language
+    attributes:
+      label: Language
+      placeholder: Italian
+    validations:
+      required: true
+
+  - type: input
+    id: area
+    attributes:
+      label: Affected page or component
+      placeholder: Device detail, Settings, Deep Scan panel
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_text
+    attributes:
+      label: Current text
+      placeholder: Paste the wrong or missing text here.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_text
+    attributes:
+      label: Suggested correct text
+      placeholder: Paste the corrected translation here.
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot or additional context
+      description: Add a screenshot if the location is hard to describe.


### PR DESCRIPTION
## Summary
- add GitHub issue templates for bug reports, feature requests, translation issues, and support questions
- add issue template config with a private security reporting link
- require template usage by disabling blank issues

## Why
Structured issue templates make incoming reports easier to triage and improve the quality of bug reports and feature requests.

## Included templates
- Bug report
- Feature request
- Translation issue
- Question / support
