### PR TITLE
Enable GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [AlexRosbach]


### PR DESCRIPTION
Adds .github/FUNDING.yml with AlexRosbach as the GitHub Sponsors account so the repository Sponsor button can appear.