### PR TITLE
fix(1.5.8): restore SSH private keys — build 20260728.0001

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project should be documented in this file.
 - Made the Network Topology map roomier and interactive with drag-to-pan, mouse-wheel zoom, inline zoom/reset controls, an offline-device visibility toggle and draggable device cards whose relationship lines stay attached, including multi-row device placement so dense device groups no longer stack on top of each other.
 
 ### Fixes / Hardening
+- Restored SSH private-key credential tests and deep scans with Paramiko 4 and newer by treating the removed legacy DSS key class as optional.
 - Ignored common Linux bridge interfaces such as `br0` and `bridge0` during first-run subnet detection so Docker hosts prefer the real LAN interface.
 - Limited the Settings SNMP custom-result request to the visible result count and kept SNMP vendor detection coverage in the dedicated vendor test.
 - Kept custom SNMP query failures isolated from the main switch poll once core SNMP polling succeeds, while still recording the custom-query failure in diagnostics.

--- a/backend/routers/credentials.py
+++ b/backend/routers/credentials.py
@@ -214,7 +214,11 @@ def _load_private_key(key_text: str):
     try:
         import paramiko  # type: ignore
         import io
-        for cls in (paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey, paramiko.DSSKey):
+        key_classes = (paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey)
+        dss_key = getattr(paramiko, "DSSKey", None)
+        if dss_key is not None:
+            key_classes += (dss_key,)
+        for cls in key_classes:
             try:
                 return cls.from_private_key(io.StringIO(key_text))
             except Exception:

--- a/backend/services/deep_scanner.py
+++ b/backend/services/deep_scanner.py
@@ -556,11 +556,15 @@ def _run_windows_scan(
 # ── SSH helpers ───────────────────────────────────────────────────────────────
 
 def _load_ssh_private_key(key_text: str):
-    """Try to load an SSH private key from PEM string. Tries RSA, Ed25519, ECDSA, DSS."""
+    """Try to load an SSH private key from PEM string."""
     try:
         import paramiko  # type: ignore
         import io
-        for cls in (paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey, paramiko.DSSKey):
+        key_classes = (paramiko.RSAKey, paramiko.Ed25519Key, paramiko.ECDSAKey)
+        dss_key = getattr(paramiko, "DSSKey", None)
+        if dss_key is not None:
+            key_classes += (dss_key,)
+        for cls in key_classes:
             try:
                 return cls.from_private_key(io.StringIO(key_text))
             except Exception:

--- a/backend/tests/test_ssh_private_keys.py
+++ b/backend/tests/test_ssh_private_keys.py
@@ -1,0 +1,31 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from backend.routers.credentials import _load_private_key
+from backend.services.deep_scanner import _load_ssh_private_key
+
+
+class _AcceptedKey:
+    @classmethod
+    def from_private_key(cls, key_file):
+        return ("accepted", key_file.read())
+
+
+class _RejectedKey:
+    @classmethod
+    def from_private_key(cls, key_file):
+        raise ValueError("wrong key type")
+
+
+@pytest.mark.parametrize("loader", [_load_private_key, _load_ssh_private_key])
+def test_private_key_loader_works_without_removed_dss_key(monkeypatch, loader):
+    paramiko_without_dss = SimpleNamespace(
+        RSAKey=_AcceptedKey,
+        Ed25519Key=_RejectedKey,
+        ECDSAKey=_RejectedKey,
+    )
+    monkeypatch.setitem(sys.modules, "paramiko", paramiko_without_dss)
+
+    assert loader("private-key-data") == ("accepted", "private-key-data")

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,7 +1,7 @@
 import os
 
 APP_VERSION = os.getenv("LANLENS_APP_VERSION", "1.5.8")
-BUILD_CODE = os.getenv("LANLENS_BUILD_CODE", "20260718.0035")
+BUILD_CODE = os.getenv("LANLENS_BUILD_CODE", "20260728.0001")
 BUILD_COMMIT = os.getenv("LANLENS_BUILD_COMMIT", "unknown")
 BUILD_BRANCH = os.getenv("LANLENS_BUILD_BRANCH", "unknown")
 BUILD_CREATED = os.getenv("LANLENS_BUILD_CREATED", "unknown")

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1086,7 +1086,7 @@ Credentials of type `linux_ssh` support two authentication methods:
 | `auth_method` | Secret content | Notes |
 |---|---|---|
 | `password` (default) | SSH password | Standard password-based SSH login |
-| `key` | PEM private key (RSA, Ed25519, ECDSA, DSS) | Key stored Fernet-encrypted; supports all paramiko key types |
+| `key` | PEM private key (RSA, Ed25519, ECDSA) | Key stored Fernet-encrypted; supports Paramiko's current secure key types |
 
 Select the auth method in the Credential Modal. The private key is stored encrypted and never returned by the API.
 

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,6 +1,6 @@
 export const APP_VERSION = '1.5.8'
 export const GITHUB_REPO = 'AlexRosbach/LanLens'
-export const BUILD_CODE = import.meta.env.VITE_LANLENS_BUILD_CODE || '20260718.0035'
+export const BUILD_CODE = import.meta.env.VITE_LANLENS_BUILD_CODE || '20260728.0001'
 export const BUILD_COMMIT = import.meta.env.VITE_LANLENS_BUILD_COMMIT || 'unknown'
 export const BUILD_BRANCH = import.meta.env.VITE_LANLENS_BUILD_BRANCH || 'unknown'
 export const BUILD_CREATED = import.meta.env.VITE_LANLENS_BUILD_CREATED || 'unknown'


### PR DESCRIPTION
## Summary

- restore RSA, Ed25519, and ECDSA private-key parsing with Paramiko 4/5
- keep legacy DSS loading optional when running on Paramiko 3
- cover both credential tests and deep-scan key loading with a regression test
- update build metadata and current SSH credential documentation

Fixes #107.

## Root cause

Paramiko 4 removed `DSSKey`. Constructing the key-class tuple accessed that missing attribute before LanLens could try any supported key type, so RSA, Ed25519, and ECDSA credentials all failed.

## Validation

- `SECRET_KEY=... python3 -m pytest -q backend/tests` — 156 passed
- `npm run build` — passed
- production Docker image built and pushed as `alexrosbach/lanlens:test`
- published image verified with Paramiko 5.0.0 by generating and parsing a real RSA private key through both LanLens key loaders
- image metadata: LanLens 1.5.8, build `20260728.0001`, commit `a0dfd3541361a36644b29f78489b9087d11ec1ea`

## Dependency and license impact

No dependency was added or changed. Paramiko remains covered by the existing LGPL-2.1 attribution.
