### PR TITLE
Build 20260812.0001: keep routed inventory identities distinct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ All notable changes to this project should be documented in this file.
 
 ### Fixes / Hardening
 - Kept routed Nmap discoveries as separate IP-based inventory entries even
-  when Docker ipvlan or another shared interface reports the same MAC address
-  for multiple reachable hosts.
+  when Docker ipvlan, proxy ARP or another shared interface reports the same
+  MAC address for multiple reachable hosts, including when ARP and routed scan
+  ranges overlap.
 - Kept Settings compatible with older settings responses by deriving an initial
   DHCP range from the legacy start/end fields when `dhcp_ranges` is absent.
 - Fixed the documented `LANLENS_API_TOKEN` and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ All notable changes to this project should be documented in this file.
 - Made the Network Topology map roomier and interactive with drag-to-pan, mouse-wheel zoom, inline zoom/reset controls, an offline-device visibility toggle and draggable device cards whose relationship lines stay attached, including multi-row device placement so dense device groups no longer stack on top of each other.
 
 ### Fixes / Hardening
+- Kept routed Nmap discoveries as separate IP-based inventory entries even
+  when Docker ipvlan or another shared interface reports the same MAC address
+  for multiple reachable hosts.
 - Kept Settings compatible with older settings responses by deriving an initial
   DHCP range from the legacy start/end fields when `dhcp_ranges` is absent.
 - Fixed the documented `LANLENS_API_TOKEN` and

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ LanLens forces a password change after the first login. For full MAC/vendor disc
 
 ## Deployment Notes
 
-LanLens uses `network_mode: host` by default because local ARP discovery and first-run subnet detection need raw network access on the host interface. Bridge mode can serve the UI, but direct ARP/MAC discovery will not work the same way and may require manually configured scan targets.
+LanLens uses `network_mode: host` by default because local ARP discovery and first-run subnet detection need raw network access on the host interface. Bridge mode can serve the UI, but direct ARP/MAC discovery will not work the same way and may require manually configured scan targets. Additional routed Nmap targets are tracked by IP so hosts such as Docker ipvlan containers remain separate even when they expose a shared MAC address.
 
 Core runtime settings:
 

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -79,6 +79,7 @@ def _get_setting_row(db: Session, key: str) -> Optional[Setting]:
 class DiscoveryResult:
     ip: str
     mac: Optional[str] = None
+    source: str = "direct"
 
 
 def _pseudo_mac_for_ip(ip: str) -> str:
@@ -177,19 +178,33 @@ def _nmap_ping_scan(targets: List[str]) -> List[DiscoveryResult]:
             # A MAC reported by a routed ping scan is not a safe device
             # identity. In particular, Docker ipvlan endpoints can expose the
             # same parent-interface MAC for many independent IP addresses.
-            # Track routed discoveries by stable IP-derived identifiers;
-            # direct ARP results for the same IP still win during deduplication.
-            results.append(DiscoveryResult(ip=ip))
+            # Track routed discoveries by stable IP-derived identifiers. Their
+            # routed source marker also prevents overlapping proxy-ARP replies
+            # from replacing that identity during deduplication.
+            results.append(DiscoveryResult(ip=ip, source="routed"))
 
     return results
 
 
 def _dedupe_discovery_results(results: List[DiscoveryResult]) -> List[DiscoveryResult]:
-    """Deduplicate discoveries by IP, preferring entries with real MAC addresses."""
+    """Deduplicate discoveries by IP while preserving routed identity semantics.
+
+    An explicit routed target must stay IP-based even when an overlapping ARP
+    scan receives a proxy-ARP response for the same address. Otherwise the
+    proxy MAC wins here and routed hosts collapse back into one device.
+    """
     by_ip: dict[str, DiscoveryResult] = {}
     for result in results:
         existing = by_ip.get(result.ip)
-        if existing is None or (not existing.mac and result.mac):
+        if (
+            existing is None
+            or (result.source == "routed" and existing.source != "routed")
+            or (
+                result.source == existing.source
+                and not existing.mac
+                and result.mac
+            )
+        ):
             by_ip[result.ip] = result
     return list(by_ip.values())
 

--- a/backend/services/scanner.py
+++ b/backend/services/scanner.py
@@ -167,18 +167,19 @@ def _nmap_ping_scan(targets: List[str]) -> List[DiscoveryResult]:
             continue
 
         ip = None
-        mac = None
         for address in host.findall("address"):
             addr_type = address.attrib.get("addrtype")
             if addr_type == "ipv4":
                 ip = address.attrib.get("addr")
-            elif addr_type == "mac":
-                raw_mac = address.attrib.get("addr")
-                mac = normalize_mac(raw_mac) if raw_mac else None
 
         if ip and ip not in seen_ips:
             seen_ips.add(ip)
-            results.append(DiscoveryResult(ip=ip, mac=mac))
+            # A MAC reported by a routed ping scan is not a safe device
+            # identity. In particular, Docker ipvlan endpoints can expose the
+            # same parent-interface MAC for many independent IP addresses.
+            # Track routed discoveries by stable IP-derived identifiers;
+            # direct ARP results for the same IP still win during deduplication.
+            results.append(DiscoveryResult(ip=ip))
 
     return results
 

--- a/backend/tests/test_routed_device_identity.py
+++ b/backend/tests/test_routed_device_identity.py
@@ -1,0 +1,120 @@
+import asyncio
+import os
+import unittest
+from unittest.mock import AsyncMock, Mock, patch
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-routed-identity-12345")
+
+from backend.database import Base
+from backend.models import Device, ScanRun, Setting
+from backend.services.scanner import DiscoveryResult, _nmap_ping_scan, run_scan
+
+
+NMAP_SHARED_MAC_XML = """\
+<?xml version="1.0"?>
+<nmaprun>
+  <host>
+    <status state="up"/>
+    <address addr="10.10.50.60" addrtype="ipv4"/>
+    <address addr="02:42:AC:11:00:02" addrtype="mac"/>
+  </host>
+  <host>
+    <status state="up"/>
+    <address addr="10.10.50.61" addrtype="ipv4"/>
+    <address addr="02:42:AC:11:00:02" addrtype="mac"/>
+  </host>
+</nmaprun>
+"""
+
+
+class RoutedDeviceIdentityTests(unittest.TestCase):
+    def setUp(self):
+        self.engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(self.engine)
+        self.Session = sessionmaker(bind=self.engine)
+
+    def tearDown(self):
+        Base.metadata.drop_all(self.engine)
+
+    def test_nmap_results_do_not_use_shared_mac_as_routed_identity(self):
+        completed = Mock(returncode=0, stdout=NMAP_SHARED_MAC_XML, stderr="")
+        with patch("backend.services.scanner.subprocess.run", return_value=completed):
+            results = _nmap_ping_scan(["10.10.50.0/24"])
+
+        self.assertEqual(
+            results,
+            [
+                DiscoveryResult(ip="10.10.50.60"),
+                DiscoveryResult(ip="10.10.50.61"),
+            ],
+        )
+
+    def test_scan_keeps_routed_hosts_as_separate_inventory_entries(self):
+        db = self.Session()
+        db.add_all([
+            Setting(key="scan_start", value="192.0.2.1"),
+            Setting(key="scan_end", value="192.0.2.254"),
+            Setting(key="scan_additional_targets", value="10.10.50.0/24"),
+            Setting(key="notify_on_new_device", value="false"),
+        ])
+        db.commit()
+        db.close()
+
+        routed_results = [
+            DiscoveryResult(ip="10.10.50.60"),
+            DiscoveryResult(ip="10.10.50.61"),
+            DiscoveryResult(ip="10.10.50.62"),
+        ]
+        hostnames = {
+            "10.10.50.60": "iperf3",
+            "10.10.50.61": "it-tools",
+            "10.10.50.62": "vaultwarden",
+        }
+
+        with patch("backend.services.scanner.SessionLocal", self.Session), patch(
+            "backend.services.scanner._arp_scan",
+            return_value=[],
+        ), patch(
+            "backend.services.scanner._nmap_ping_scan",
+            return_value=routed_results,
+        ), patch(
+            "backend.services.scanner._detect_local_host_result",
+            return_value=None,
+        ), patch(
+            "backend.services.scanner._measure_scan_latencies",
+            new=AsyncMock(return_value={}),
+        ), patch(
+            "backend.services.scanner._get_hostname",
+            side_effect=lambda ip: hostnames[ip],
+        ), patch(
+            "backend.services.scanner._send_notification_deliveries",
+            new=AsyncMock(),
+        ):
+            self.assertIsNotNone(asyncio.run(run_scan("test")))
+
+        db = self.Session()
+        try:
+            scan_run = db.query(ScanRun).order_by(ScanRun.id.desc()).one()
+            self.assertEqual(scan_run.status, "done")
+            self.assertEqual(scan_run.devices_found, 3)
+            self.assertEqual(scan_run.devices_new, 3)
+            devices = db.query(Device).order_by(Device.ip_address).all()
+            self.assertEqual(
+                [(row.ip_address, row.hostname) for row in devices],
+                [
+                    ("10.10.50.60", "iperf3"),
+                    ("10.10.50.61", "it-tools"),
+                    ("10.10.50.62", "vaultwarden"),
+                ],
+            )
+            self.assertEqual(len({row.mac_address for row in devices}), 3)
+            self.assertTrue(all(row.mac_address.startswith("ip:") for row in devices))
+        finally:
+            db.close()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_routed_device_identity.py
+++ b/backend/tests/test_routed_device_identity.py
@@ -10,7 +10,7 @@ os.environ.setdefault("SECRET_KEY", "test-secret-key-for-routed-identity-12345")
 
 from backend.database import Base
 from backend.models import Device, ScanRun, Setting
-from backend.services.scanner import DiscoveryResult, _nmap_ping_scan, run_scan
+from backend.services.scanner import DiscoveryResult, _dedupe_discovery_results, _nmap_ping_scan, run_scan
 
 
 NMAP_SHARED_MAC_XML = """\
@@ -47,8 +47,25 @@ class RoutedDeviceIdentityTests(unittest.TestCase):
         self.assertEqual(
             results,
             [
-                DiscoveryResult(ip="10.10.50.60"),
-                DiscoveryResult(ip="10.10.50.61"),
+                DiscoveryResult(ip="10.10.50.60", source="routed"),
+                DiscoveryResult(ip="10.10.50.61", source="routed"),
+            ],
+        )
+
+    def test_routed_result_wins_over_proxy_arp_for_the_same_ip(self):
+        shared_mac = "02:42:AC:11:00:02"
+        results = _dedupe_discovery_results([
+            DiscoveryResult(ip="10.10.50.60", mac=shared_mac),
+            DiscoveryResult(ip="10.10.50.61", mac=shared_mac),
+            DiscoveryResult(ip="10.10.50.60", source="routed"),
+            DiscoveryResult(ip="10.10.50.61", source="routed"),
+        ])
+
+        self.assertEqual(
+            results,
+            [
+                DiscoveryResult(ip="10.10.50.60", source="routed"),
+                DiscoveryResult(ip="10.10.50.61", source="routed"),
             ],
         )
 
@@ -64,9 +81,9 @@ class RoutedDeviceIdentityTests(unittest.TestCase):
         db.close()
 
         routed_results = [
-            DiscoveryResult(ip="10.10.50.60"),
-            DiscoveryResult(ip="10.10.50.61"),
-            DiscoveryResult(ip="10.10.50.62"),
+            DiscoveryResult(ip="10.10.50.60", source="routed"),
+            DiscoveryResult(ip="10.10.50.61", source="routed"),
+            DiscoveryResult(ip="10.10.50.62", source="routed"),
         ]
         hostnames = {
             "10.10.50.60": "iperf3",
@@ -110,6 +127,52 @@ class RoutedDeviceIdentityTests(unittest.TestCase):
                     ("10.10.50.62", "vaultwarden"),
                 ],
             )
+            self.assertEqual(len({row.mac_address for row in devices}), 3)
+            self.assertTrue(all(row.mac_address.startswith("ip:") for row in devices))
+        finally:
+            db.close()
+
+    def test_scan_keeps_routed_hosts_distinct_when_proxy_arp_reports_one_mac(self):
+        db = self.Session()
+        db.add_all([
+            Setting(key="scan_start", value="192.0.2.1"),
+            Setting(key="scan_end", value="192.0.2.254"),
+            Setting(key="scan_additional_targets", value="10.10.50.0/24"),
+            Setting(key="notify_on_new_device", value="false"),
+        ])
+        db.commit()
+        db.close()
+
+        shared_mac = "02:42:AC:11:00:02"
+        ips = ["10.10.50.60", "10.10.50.61", "10.10.50.62"]
+        arp_results = [DiscoveryResult(ip=ip, mac=shared_mac) for ip in ips]
+        routed_results = [DiscoveryResult(ip=ip, source="routed") for ip in ips]
+
+        with patch("backend.services.scanner.SessionLocal", self.Session), patch(
+            "backend.services.scanner._arp_scan",
+            return_value=arp_results,
+        ), patch(
+            "backend.services.scanner._nmap_ping_scan",
+            return_value=routed_results,
+        ), patch(
+            "backend.services.scanner._detect_local_host_result",
+            return_value=None,
+        ), patch(
+            "backend.services.scanner._measure_scan_latencies",
+            new=AsyncMock(return_value={}),
+        ), patch(
+            "backend.services.scanner._get_hostname",
+            side_effect=lambda ip: f"host-{ip.rsplit('.', 1)[-1]}",
+        ), patch(
+            "backend.services.scanner._send_notification_deliveries",
+            new=AsyncMock(),
+        ):
+            self.assertIsNotNone(asyncio.run(run_scan("test")))
+
+        db = self.Session()
+        try:
+            devices = db.query(Device).order_by(Device.ip_address).all()
+            self.assertEqual([row.ip_address for row in devices], ips)
             self.assertEqual(len({row.mac_address for row in devices}), 3)
             self.assertTrue(all(row.mac_address.startswith("ip:") for row in devices))
         finally:

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,7 +1,7 @@
 import os
 
 APP_VERSION = os.getenv("LANLENS_APP_VERSION", "1.5.9")
-BUILD_CODE = os.getenv("LANLENS_BUILD_CODE", "20260730.0018")
+BUILD_CODE = os.getenv("LANLENS_BUILD_CODE", "20260731.0001")
 BUILD_COMMIT = os.getenv("LANLENS_BUILD_COMMIT", "unknown")
 BUILD_BRANCH = os.getenv("LANLENS_BUILD_BRANCH", "unknown")
 BUILD_CREATED = os.getenv("LANLENS_BUILD_CREATED", "unknown")

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,7 +1,7 @@
 import os
 
 APP_VERSION = os.getenv("LANLENS_APP_VERSION", "1.5.9")
-BUILD_CODE = os.getenv("LANLENS_BUILD_CODE", "20260731.0001")
+BUILD_CODE = os.getenv("LANLENS_BUILD_CODE", "20260808.0001")
 BUILD_COMMIT = os.getenv("LANLENS_BUILD_COMMIT", "unknown")
 BUILD_BRANCH = os.getenv("LANLENS_BUILD_BRANCH", "unknown")
 BUILD_CREATED = os.getenv("LANLENS_BUILD_CREATED", "unknown")

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -420,7 +420,9 @@ Returns a `.rdp` file download with the device's IP pre-configured.
 6. Optional routed scan targets are scanned with `nmap -sn -oX - <target>`
 7. For each discovered host:
    a. Normalize MAC to XX:XX:XX:XX:XX:XX when available
-   b. Routed hosts without MAC receive a stable internal `ip:` identifier and are displayed as IP-only discoveries
+   b. Routed hosts receive a stable internal `ip:` identifier and are displayed
+      as IP-only discoveries, because a MAC reported beyond the direct ARP
+      range may belong to a router or a shared Docker ipvlan interface
    c. mac_vendor.py: manuf.MacParser().get_manuf(mac) → vendor string when a real MAC exists
    d. DB upsert:
       - If identifier exists: update ip, last_seen, is_online=True

--- a/docs/knowledgebase.md
+++ b/docs/knowledgebase.md
@@ -8,7 +8,7 @@ This page collects common setup issues and fixes for LanLens integrations.
 
 Treat this as two separate problems: discovery reachability and CMDB reconciliation.
 
-For VLAN discovery, use **Settings -> Network -> Additional routed scan targets** for routed CIDRs that the LanLens host can reach, for example `10.10.20.0/24`. LanLens uses `nmap -sn` for those targets. Across routed networks, MAC/vendor data may be missing because ARP only works reliably inside the local broadcast domain.
+For VLAN discovery, use **Settings -> Network -> Additional routed scan targets** for routed CIDRs that the LanLens host can reach, for example `10.10.20.0/24`. LanLens uses `nmap -sn` for those targets and tracks each reachable address with a stable IP-based identity. This keeps Docker ipvlan containers and other hosts separate even when the scan sees a shared MAC. Across routed networks, MAC/vendor data is intentionally not used because ARP identity is only reliable inside the local broadcast domain.
 
 For larger enterprises, deploy one LanLens instance or scanner near each site/VLAN when MAC-level discovery matters, then consolidate through i-doit/CMDB rather than forcing one central ARP scanner through routed networks.
 

--- a/frontend/e2e/dns-names.spec.ts
+++ b/frontend/e2e/dns-names.spec.ts
@@ -16,7 +16,7 @@ const baseSettings = {
   show_build_info: false,
   show_debug_tools: false,
   app_version: '1.5.9',
-  build_code: '20260730.0018',
+  build_code: '20260731.0001',
   build_commit: 'test',
   build_branch: 'feature/1.5.9-dns-names',
   build_created: now,

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,6 +1,6 @@
 export const APP_VERSION = '1.5.9'
 export const GITHUB_REPO = 'AlexRosbach/LanLens'
-export const BUILD_CODE = import.meta.env.VITE_LANLENS_BUILD_CODE || '20260730.0018'
+export const BUILD_CODE = import.meta.env.VITE_LANLENS_BUILD_CODE || '20260731.0001'
 export const BUILD_COMMIT = import.meta.env.VITE_LANLENS_BUILD_COMMIT || 'unknown'
 export const BUILD_BRANCH = import.meta.env.VITE_LANLENS_BUILD_BRANCH || 'unknown'
 export const BUILD_CREATED = import.meta.env.VITE_LANLENS_BUILD_CREATED || 'unknown'

--- a/frontend/src/version.ts
+++ b/frontend/src/version.ts
@@ -1,6 +1,6 @@
 export const APP_VERSION = '1.5.9'
 export const GITHUB_REPO = 'AlexRosbach/LanLens'
-export const BUILD_CODE = import.meta.env.VITE_LANLENS_BUILD_CODE || '20260731.0001'
+export const BUILD_CODE = import.meta.env.VITE_LANLENS_BUILD_CODE || '20260808.0001'
 export const BUILD_COMMIT = import.meta.env.VITE_LANLENS_BUILD_COMMIT || 'unknown'
 export const BUILD_BRANCH = import.meta.env.VITE_LANLENS_BUILD_BRANCH || 'unknown'
 export const BUILD_CREATED = import.meta.env.VITE_LANLENS_BUILD_CREATED || 'unknown'


### PR DESCRIPTION
## Summary

- preserve routed Nmap discoveries as IP-based identities throughout deduplication and inventory reconciliation
- keep Docker ipvlan containers and other routed hosts separate even when proxy ARP reports one shared MAC for every IP
- repair previously collapsed inventory rows without allowing a routed result to reuse a device already claimed by a direct MAC discovery
- preserve MAC-based identity for direct ARP discoveries outside explicitly configured routed targets
- add parser, deduplication, fresh-inventory, and existing-collapsed-inventory regression coverage
- document the routed-discovery identity model in the README, documentation, knowledge base, and changelog

Fixes #121

## Why

MAC addresses observed outside the direct ARP range are not reliable device identities. Docker ipvlan endpoints can expose the same parent-interface MAC for multiple independent IP addresses. Matching every routed result by that MAC caused one inventory row to be repeatedly overwritten with different IP addresses and hostnames.

The first implementation removed MAC addresses from Nmap results, but a later IP deduplication stage still preferred an overlapping ARP/proxy-ARP result with a MAC. The second implementation preserved routed identity during per-IP deduplication, but existing collapsed rows could still be reused through a stale IP lookup after their MAC identity had already been claimed by a directly discovered device.

Discovery results now retain their source through both stages. For explicitly configured routed targets, the deterministic internal `ip:` identifier is used during inventory reconciliation. Existing collapsed rows can migrate to that identifier only when they have not already been claimed by a direct discovery, and IP lookup maps are updated as rows move. Direct ARP-only discoveries remain MAC-based.

## Validation

- 177 backend tests passed
- 5 focused routed-identity tests passed again inside the production image
- frontend production build passed (977 modules)
- Docker build and `/api/health` smoke test passed
- version/build metadata: `1.5.9` / `20260812.0001` / `675b5bb`
- AMD64 image digest: `sha256:e7d3c713c27e9ec232c3e76e39a42e01c7ed39e0a84e7c22f78042ebea3a5c38`
- no new dependencies; license set unchanged

## Test image

```bash
docker pull alexrosbach/lanlens:1.5.9-dev
docker compose up -d --force-recreate
```

After upgrading, run a network scan and verify that the routed Docker containers appear as separate inventory entries. The `1.5.9`, `latest`, `test`, and 1.6.0 development tags are unchanged.
